### PR TITLE
v3.1

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.relluem94</groupId>
   <artifactId>relluessentials</artifactId>
   <name>RelluEssentials</name>
-  <version>3.0</version>
+  <version>3.1</version>
   <url>https://github.com/Relluem94s/RelluEssentials</url>
   <scm>
     <connection>scm:git:git@github.com:Relluem94s/RelluEssentials.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.31</version>
+            <version>8.0.33</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>de.relluem94</groupId>
     <artifactId>relluessentials</artifactId>
     <name>RelluEssentials</name>
-    <version>3.0</version>
+    <version>3.1</version>
     <url>https://github.com/Relluem94s/RelluEssentials</url>
     <properties>
         <plugin.apiVersion>1.19</plugin.apiVersion>

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/Strings.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/Strings.java
@@ -276,6 +276,7 @@ public class Strings {
     public static final String PLUGIN_COMMAND_BAGS_NOT_FOUND = PLUGIN_FORMS_COMMAND_PREFIX + "The searched Bag " + PLUGIN_COLOR_COMMAND_ARG + "%s " + PLUGIN_COLOR_COMMAND + "was not found!";
 
     public static final String PLUGIN_COMMAND_MARRY_SEND_REQUEST = PLUGIN_FORMS_COMMAND_PREFIX + "Du hast eine Hochzeitsanfrage an " + PLUGIN_COLOR_COMMAND_ARG + "%s" + PLUGIN_COLOR_COMMAND + " geschickt!";
+    public static final String PLUGIN_COMMAND_MARRY_RECEIVE_REQUEST = PLUGIN_FORMS_COMMAND_PREFIX + "Du hast eine Hochzeitsanfrage von " + PLUGIN_COLOR_COMMAND_ARG + "%s" + PLUGIN_COLOR_COMMAND + " bekommen!";
     public static final String PLUGIN_COMMAND_MARRY_MARRIED = PLUGIN_FORMS_COMMAND_PREFIX + "Du hast " + PLUGIN_COLOR_COMMAND_ARG + "%s " + PLUGIN_COLOR_COMMAND + "geheiratet!";
     public static final String PLUGIN_COMMAND_MARRY_REQUEST_EXPIRED = PLUGIN_FORMS_COMMAND_PREFIX + "Hochzeitsanfrage ist abgelaufen!";
     public static final String PLUGIN_COMMAND_MARRY_REQUEST_IS_MAARIED = PLUGIN_FORMS_COMMAND_PREFIX + "Hochzeitsanfrage ist ungültig, Spieler ist bereits verheitratet!";

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Home.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Home.java
@@ -135,6 +135,15 @@ public class Home implements CommandExecutor {
                                 p.sendMessage(String.format(PLUGIN_COMMAND_HOME_DEATH_DELETE, args[1]));
                                 return true;
                             }
+                            else if(le.getLocationName().startsWith("death_") && le.getLocationName().contains("*")){
+                                for(LocationEntry dle : pe.getDeaths()){
+                                    p.sendMessage(String.format(PLUGIN_COMMAND_HOME_DEATH_DELETE, dle.getLocationName()));
+                                    RelluEssentials.getInstance().getDatabaseHelper().deleteLocation(dle);
+                                }
+
+                                pe.getDeaths().clear();
+                                return true;
+                            }
                             else {
                                 p.sendMessage(String.format(PLUGIN_COMMAND_HOME_NOT_FOUND, args[1]));
                                 return true;

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Marry.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Marry.java
@@ -1,20 +1,18 @@
 package de.relluem94.minecraft.server.spigot.essentials.commands;
 
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
-import de.relluem94.minecraft.server.spigot.essentials.permissions.Permission;
-import de.relluem94.minecraft.server.spigot.essentials.RelluEssentials;
-import de.relluem94.minecraft.server.spigot.essentials.events.BetterLock;
-import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.PlayerEntry;
-import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.PlayerPartnerEntry;
-import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.ProtectionEntry;
-import de.relluem94.minecraft.server.spigot.essentials.permissions.Groups;
-import static de.relluem94.minecraft.server.spigot.essentials.Strings.*;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_ACCEPT_NO_REQUEST;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_DIVORCED;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_DIVORCE_NOT_MARRIED;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_INFO;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_MARRIED;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_RECEIVE_REQUEST;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_REQUEST_EXPIRED;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_REQUEST_IS_MAARIED;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_SELF_MARRIGE;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_MARRY_SEND_REQUEST;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_PERMISSION_MISSING;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_TARGET_NOT_A_PLAYER;
+import static de.relluem94.minecraft.server.spigot.essentials.Strings.PLUGIN_COMMAND_TO_MANY_ARGUMENTS;
 import static de.relluem94.minecraft.server.spigot.essentials.constants.CommandNameConstants.PLUGIN_COMMAND_NAME_MARRY;
 import static de.relluem94.minecraft.server.spigot.essentials.constants.CommandNameConstants.PLUGIN_COMMAND_NAME_MARRY_ACCEPT;
 import static de.relluem94.minecraft.server.spigot.essentials.constants.CommandNameConstants.PLUGIN_COMMAND_NAME_MARRY_DIVORCE;
@@ -24,6 +22,21 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import de.relluem94.minecraft.server.spigot.essentials.RelluEssentials;
+import de.relluem94.minecraft.server.spigot.essentials.events.BetterLock;
+import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.PlayerEntry;
+import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.PlayerPartnerEntry;
+import de.relluem94.minecraft.server.spigot.essentials.helpers.pojo.ProtectionEntry;
+import de.relluem94.minecraft.server.spigot.essentials.permissions.Groups;
+import de.relluem94.minecraft.server.spigot.essentials.permissions.Permission;
 
 public class Marry implements CommandExecutor {
 
@@ -36,6 +49,7 @@ public class Marry implements CommandExecutor {
         }
 
         player.sendMessage(String.format(PLUGIN_COMMAND_MARRY_SEND_REQUEST, target.getCustomName()));
+        target.sendMessage(String.format(PLUGIN_COMMAND_MARRY_RECEIVE_REQUEST, player.getCustomName()));
 
         marryAcceptList.put(target, player);
         Bukkit.getScheduler().runTaskLater(RelluEssentials.getInstance(), () -> {

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/PlayerInfo.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/PlayerInfo.java
@@ -102,7 +102,7 @@ public class PlayerInfo implements CommandExecutor {
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_MINED, Material.SAND.name(), target.getStatistic(Statistic.MINE_BLOCK, Material.SAND)));
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_MINED, Material.COBBLESTONE.name(), target.getStatistic(Statistic.MINE_BLOCK, Material.COBBLESTONE)));
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_MINED, Material.DEEPSLATE.name(), target.getStatistic(Statistic.MINE_BLOCK, Material.DEEPSLATE)));
-        sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_MINED, Material.DIAMOND.name(), target.getStatistic(Statistic.MINE_BLOCK, Material.DIAMOND)));
+        sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_MINED, Material.DIAMOND_ORE.name(), target.getStatistic(Statistic.MINE_BLOCK, Material.DIAMOND_ORE) + target.getStatistic(Statistic.MINE_BLOCK, Material.DEEPSLATE_DIAMOND_ORE)));
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_DEATHS, target.getStatistic(Statistic.DEATHS)));
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_JUMPED, target.getStatistic(Statistic.JUMP)));
         sender.sendMessage(String.format(PLUGIN_COMMAND_PLAYERINFO_LEFT_GAME, target.getStatistic(Statistic.LEAVE_GAME)));

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Suicide.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Suicide.java
@@ -56,6 +56,7 @@ public class Suicide implements CommandExecutor {
 
         if (args.length == 0) {
             suicide(p);
+            return true;
         } 
 
         Player target = Bukkit.getPlayer(args[0]);

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Teleport.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/commands/Teleport.java
@@ -80,13 +80,14 @@ public class Teleport implements CommandExecutor {
     public void teleport(Player p, Player t){
         Back.addBackPoint(t);
         t.teleport(p);
-        p.sendMessage(String.format(PLUGIN_COMMAND_TP, t.getCustomName()));
+        t.sendMessage(String.format(PLUGIN_COMMAND_TP, t.getCustomName()));
     }
 
     public void teleportTo(Player p, Player t){
         Back.addBackPoint(p);
         p.teleport(t);
-        t.sendMessage(String.format(PLUGIN_COMMAND_TP_TO, p.getCustomName()));
+        p.sendMessage(String.format(PLUGIN_COMMAND_TP_TO, p.getCustomName()));
+        t.sendMessage(String.format(PLUGIN_COMMAND_TP, t.getCustomName()));
     }
 
 

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
@@ -50,7 +50,8 @@ public class BetterBags implements Listener {
         Material m = e.getBlock().getType();
         
         if(p.getInventory().getItemInMainHand() != null && EnchantmentHelper.hasEnchant(p.getInventory().getItemInMainHand(), CustomEnchants.delicate)){
-            if(e.getBlock().getType().equals(Material.PUMPKIN_STEM) || e.getBlock().getType().equals(Material.MELON_STEM)){
+            if(e.getBlock().getType().equals(Material.PUMPKIN_STEM) || e.getBlock().getType().equals(Material.MELON_STEM) ||
+            e.getBlock().getType().equals(Material.ATTACHED_PUMPKIN_STEM) || e.getBlock().getType().equals(Material.ATTACHED_MELON_STEM)){
                 e.setCancelled(true);
             } 
             

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
@@ -6,6 +6,8 @@ import java.util.Random;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Ageable;
@@ -289,10 +291,14 @@ public class BetterBags implements Listener {
                     int coins = im.getPersistentDataContainer().get(ItemConstants.PLUGIN_ITEM_COINS_NAMESPACE, PersistentDataType.INTEGER) * is.getAmount();
                     ChatHelper.sendMessageInActionBar(p, String.format(Strings.PLUGIN_COMMAND_PURSE_GAIN, StringHelper.formatInt(coins), StringHelper.formatDouble(pe.getPurse() + coins)));
                     pe.setPurse(pe.getPurse() + coins);
+
+                    p.playSound(p, Sound.ITEM_ARMOR_EQUIP_GOLD, SoundCategory.PLAYERS, 1F, 1);
+
                     pe.setUpdatedBy(pe.getID());
                     pe.setToBeUpdated(false);
+
+                    e.getItem().getItemStack().setAmount(0);
                     e.setCancelled(true);
-                    e.getItem().remove();
                 }
             }
 

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterBags.java
@@ -314,6 +314,7 @@ public class BetterBags implements Listener {
                 p.updateInventory();
                 e.setCancelled(true);
                 e.getItem().remove();
+                p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.5f, 1f);
             }
         }
     }

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterLock.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterLock.java
@@ -97,7 +97,7 @@ public class BetterLock implements Listener {
         Block block = e.getToBlock();
         if (unBreakable.contains(block.getType())){
             if(RelluEssentials.getInstance().getProtectionAPI().getProtectionEntry(block.getLocation()) != null){
-                e.setCancelled(true); 
+                e.setCancelled(true);
             }
         }
     }
@@ -844,7 +844,7 @@ public class BetterLock implements Listener {
         for (Block b : e.getBlocks()) {
             ProtectionEntry protection = RelluEssentials.getInstance().getProtectionAPI().getProtectionEntry(b.getLocation());
             if (protection != null || isProtected(b, BlockFace.UP) || isProtected(b, BlockFace.DOWN)) {
-                e.setCancelled(true);
+                e.setCancelled(!b.getType().equals(Material.WATER));
                 break;
             }
         } 

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterLock.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/BetterLock.java
@@ -843,14 +843,10 @@ public class BetterLock implements Listener {
     public void onBlockPistonExtend(BlockPistonExtendEvent e) {
         for (Block b : e.getBlocks()) {
             ProtectionEntry protection = RelluEssentials.getInstance().getProtectionAPI().getProtectionEntry(b.getLocation());
-            if (protection != null) {
+            if (protection != null || isProtected(b, BlockFace.UP) || isProtected(b, BlockFace.DOWN)) {
                 e.setCancelled(true);
                 break;
             }
-            if(isProtected(b, BlockFace.UP) || isProtected(b, BlockFace.DOWN)){
-                e.setCancelled(true);
-                break;
-            } 
         } 
     }
 
@@ -858,15 +854,10 @@ public class BetterLock implements Listener {
     public void onBlockPistonRetract(BlockPistonRetractEvent e) {    
         for (Block b : e.getBlocks()) {
             ProtectionEntry protection = RelluEssentials.getInstance().getProtectionAPI().getProtectionEntry(b.getLocation());
-            if (protection != null) {
+            if (protection != null || isProtected(b, BlockFace.UP) || isProtected(b, BlockFace.DOWN)) {
                 e.setCancelled(true);
                 break;
-            } 
-
-            if(isProtected(b, BlockFace.UP) || isProtected(b, BlockFace.DOWN)){
-                e.setCancelled(true);
-                break;
-            } 
+            }
         } 
     }
 

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/NoDeathMessage.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/events/NoDeathMessage.java
@@ -7,6 +7,7 @@ import static de.relluem94.minecraft.server.spigot.essentials.constants.EventCon
 import java.util.Random;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -35,26 +36,32 @@ public class NoDeathMessage implements Listener {
         e.setDeathMessage(null);
 
         Player p = e.getEntity().getPlayer();
+        Location ploc = p.getLocation();
+        Location location = new Location(ploc.getWorld(), ploc.getBlockX(), ploc.getBlockY(), ploc.getBlockZ(), ploc.getYaw(), ploc.getPitch());
 
         PlayerEntry pe = RelluEssentials.getInstance().getPlayerAPI().getPlayerEntry(p.getUniqueId());
         LocationEntry le = new LocationEntry();
-        le.setLocation(p.getLocation());
-        le.setLocationName(String.format(PLUGIN_EVENT_NO_DEATH_MESSAGE, random.nextInt(94)));
+        le.setLocation(location);
+        le.setLocationName(String.format(PLUGIN_EVENT_NO_DEATH_MESSAGE, random.nextInt(994)));
         LocationTypeEntry locationType = RelluEssentials.getInstance().locationTypeEntryList.get(1);
         le.setLocationType(locationType);
         le.setPlayerId(pe.getID());
-        RelluEssentials.getInstance().getDatabaseHelper().insertLocation(le);
-        le = RelluEssentials.getInstance().getDatabaseHelper().getLocation(p.getLocation(), locationType.getId());
-        pe.getHomes().add(le);
 
+        p.sendMessage(String.format(PLUGIN_EVENT_DEATH, le.getLocationName(), (int) le.getLocation().getX(), (int) le.getLocation().getY(), (int) le.getLocation().getZ(), le.getLocation().getWorld().getName()));
+        Bukkit.getConsoleSender().getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + p.getName() + " [\"\",{\"text\":\"" + PLUGIN_EVENT_DEATH_TP + "\",\"color\":\"aqua\",\"clickEvent\":{\"action\":\"run_command\",\"value\":\"/home " + le.getLocationName() + "\"}}]");
+        
+        RelluEssentials.getInstance().getDatabaseHelper().insertLocation(le);
+        le = RelluEssentials.getInstance().getDatabaseHelper().getLocation(location, locationType.getId());
+
+        if(le != null){
+            pe.getHomes().add(le);
+        }
+       
         for(ItemStack is : p.getInventory().getContents()){
             if(CustomItems.coins.almostEquals(is) && is.getItemMeta().getPersistentDataContainer().has(ItemConstants.PLUGIN_ITEM_COINS_NAMESPACE, PersistentDataType.INTEGER)){
                 p.getInventory().remove(is);
             }
         }
-
-        p.sendMessage(String.format(PLUGIN_EVENT_DEATH, le.getLocationName(), (int) le.getLocation().getX(), (int) le.getLocation().getY(), (int) le.getLocation().getZ(), le.getLocation().getWorld().getName()));
-        Bukkit.getConsoleSender().getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + p.getName() + " [\"\",{\"text\":\"" + PLUGIN_EVENT_DEATH_TP + "\",\"color\":\"aqua\",\"clickEvent\":{\"action\":\"run_command\",\"value\":\"/home " + le.getLocationName() + "\"}}]");
     }
 
     @EventHandler

--- a/src/main/java/de/relluem94/minecraft/server/spigot/essentials/helpers/BagHelper.java
+++ b/src/main/java/de/relluem94/minecraft/server/spigot/essentials/helpers/BagHelper.java
@@ -251,7 +251,7 @@ public class BagHelper {
                         be.setSlotValue(slot, be.getSlotValue(slot) + i.getItemStack().getAmount());
                         be.setToBeUpdated(true);
                         ChatHelper.sendMessageInActionBar(p, String.format(EventConstants.PLUGIN_EVENT_BAG_COLLECT, i.getItemStack().getAmount(), i.getName()));
-                        p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 1, 1);
+                        p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.5F, 1);
                         lio.add(i);
                     }
                 }
@@ -275,7 +275,7 @@ public class BagHelper {
                         be.setSlotValue(slot, be.getSlotValue(slot) + i.getAmount());
                         be.setToBeUpdated(true);
                         ChatHelper.sendMessageInActionBar(p, String.format(EventConstants.PLUGIN_EVENT_BAG_COLLECT, i.getAmount(), i.getType().name().replace("_", " ").toLowerCase()));
-                        p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 1, 1);
+                        p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.5F, 1);
                         lio.add(i);
                     }
                 }
@@ -298,7 +298,7 @@ public class BagHelper {
                 be.setSlotValue(slot, be.getSlotValue(slot) + item.getItemStack().getAmount());
                 be.setToBeUpdated(true);
                 ChatHelper.sendMessageInActionBar(p, String.format(EventConstants.PLUGIN_EVENT_BAG_COLLECT, item.getItemStack().getAmount(), item.getName()));
-                p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 1, 1);
+                p.playSound(p, Sound.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.5F, 1);
                 item.getItemStack().setAmount(0);
                 return true;
             }


### PR DESCRIPTION
# Release notes - RelluEssentials - v3.1

### Bug

RE-54 Delicate breaks Stems

RE-59 Teleport Accept sends message to wrong player

RE-60 Connected Stems have no Age and get destroyed by Delicate Enchantment

RE-61 Piston won't work in Water \(Kelp Farm\)

RE-62 Item Pickup Sound \(Inventory\) is missing

RE-63 Reduce Item Pickup Sound \(Bag\)

RE-64 Coin Pickup does not remove Coin Item

RE-65 Playerinfo Diamond Stat shows always 0

RE-66 Marry shows no Message to other player

RE-68 Suicide breaks Deathpoints

### Task

RE-67 Upgrade MySQL Connector Version

### New Feature

RE-69 Delete all Death Points with wildcard